### PR TITLE
Allow construction of arcs

### DIFF
--- a/figures.ts
+++ b/figures.ts
@@ -74,6 +74,73 @@ export class SegmentFigure implements Figure {
 	}
 }
 
+/**
+ * An `ArcFigure` is a partial circular arc with the provided `center` between the
+ * points `end1` and `end2`.
+ *
+ * The two points `end1` and `end2` should be equidistant to `center` for best
+ * behavior, but if not, the arc uses only the distance between `center` and `end1`
+ * as the arc radius.
+ *
+ * An `ArcFigure` cannot represent a full, 360 degree circle.
+ */
+export class ArcFigure implements Figure {
+	constructor(
+		public center: PointFigure,
+		public end1: PointFigure,
+		public end2: PointFigure,
+	) { }
+
+	dependsOn(): Figure[] {
+		return [this.center, this.end1, this.end2];
+	}
+	bounds(): geometry.Position[] {
+		const boundsPoints: geometry.Position[] = [
+			this.center.position,
+			this.end1.position,
+			this.end2.position,
+		];
+		return boundsPoints;
+	}
+
+	/**
+	 * Returns a point on the (clockwise) arc from `end1` to `end2`.
+	 *
+	 * Note that if `end1` and `end2` are not equidistant to the `center`, then the radius
+	 * is chosen using the distance to `end1`.
+	 *
+	 * If `end1` and `end2` are approximately the same angle from the center,
+	 * then linear interpolation between these ends is used instead of computing
+	 * the arc angle.
+	 *
+	 * Complete circles should always be made of multiple arcs.
+	 *
+	 * @param t parameter in range [0, 1].
+	 * @returns A point along the arc.
+	 */
+	pointFromParameter(t: number): geometry.Position {
+		const r1 = geometry.pointDistance(this.center.position, this.end1.position);
+
+		const a1 = Math.atan2(this.end1.position.y - this.center.position.y, this.end1.position.x - this.center.position.x);
+		let a2 = Math.atan2(this.end2.position.y - this.center.position.y, this.end2.position.x - this.center.position.x);
+
+		if (Math.abs(a1 - a2) < geometry.EPSILON || Math.abs(a1 - a2 - Math.PI * 2) < geometry.EPSILON || r1 < geometry.EPSILON) {
+			// There is some degeneracy in this case, so just lerp between the points instead.
+			return geometry.linearSum([1 - t, this.end1.position], [t, this.end2.position]);
+		}
+		if (a2 < a1) {
+			a2 += Math.PI * 2;
+		}
+
+		const a = a1 * (1 - t) + a2 * t;
+
+		return {
+			x: Math.cos(a) * r1 + this.center.position.x,
+			y: Math.sin(a) * r1 + this.center.position.y,
+		};
+	}
+}
+
 export class DimensionPointDistanceFigure extends AbstractDimensionFigure {
 	constructor(
 		public from: PointFigure,

--- a/graphics.ts
+++ b/graphics.ts
@@ -59,6 +59,69 @@ export function drawSketchedSegment(
 	ctx.stroke();
 }
 
+export function drawSketchedArc(
+	ctx: CanvasRenderingContext2D,
+	view: View,
+	centerWorld: Position | null,
+	end1World: Position | null,
+	end2World: Position | null,
+): void {
+	const RADII_LINE_DASH = [10, 10, 30, 10, 10, 20];
+	// Sketching a new arc
+	if (centerWorld === null) {
+		return;
+	}
+	ctx.lineWidth = SEGMENT_WIDTH;
+	ctx.lineCap = "round";
+	ctx.strokeStyle = COLOR_DRAFT;
+	const centerScreen = view.toScreen(centerWorld);
+	const end1Screen = end1World !== null ? view.toScreen(end1World) : null;
+	const end2Screen = end2World !== null ? view.toScreen(end2World) : null;
+
+
+	if (!end1Screen) {
+		// Nothing to draw.
+		return;
+	}
+
+	const radius = pointDistance(centerScreen, end1Screen);
+
+	ctx.save();
+	ctx.setLineDash(RADII_LINE_DASH);
+	ctx.beginPath();
+	ctx.moveTo(centerScreen.x, centerScreen.y);
+	ctx.lineTo(end1Screen.x, end1Screen.y);
+	ctx.stroke();
+	ctx.restore();
+
+	if (end2Screen) {
+		// Preview the output arc also.
+		ctx.beginPath();
+		ctx.arc(
+			centerScreen.x,
+			centerScreen.y,
+			radius,
+			Math.atan2(end1Screen.y - centerScreen.y, end1Screen.x - centerScreen.x),
+			Math.atan2(end2Screen.y - centerScreen.y, end2Screen.x - centerScreen.x),
+		);
+		ctx.stroke();
+	} else {
+		// Preview an arbitrary small arc, to show the direction.
+		ctx.beginPath();
+		ctx.arc(
+			centerScreen.x,
+			centerScreen.y,
+			radius,
+			Math.atan2(end1Screen.y - centerScreen.y, end1Screen.x - centerScreen.x),
+			Math.atan2(end1Screen.y - centerScreen.y, end1Screen.x - centerScreen.x) + Math.PI / 4,
+		);
+		ctx.stroke();
+	}
+
+
+
+}
+
 export function drawLengthDimension(
 	ctx: CanvasRenderingContext2D,
 	view: View,

--- a/graphics.ts
+++ b/graphics.ts
@@ -264,3 +264,39 @@ export function drawSegment(
 	ctx.strokeStyle = ink;
 	ctx.stroke();
 }
+
+export function drawArc(
+	ctx: CanvasRenderingContext2D,
+	view: View,
+	centerWorld: Position,
+	end1World: Position,
+	end2World: Position,
+	ink: string,
+): void {
+	const centerScreen = view.toScreen(centerWorld);
+	const end1Screen = view.toScreen(end1World);
+	const end2Screen = view.toScreen(end2World);
+
+	let a1 = Math.atan2(end1Screen.y - centerScreen.y, end1Screen.x - centerScreen.x);
+	let a2 = Math.atan2(end2Screen.y - centerScreen.y, end2Screen.x - centerScreen.x);
+	if (a2 < a1) {
+		a2 += Math.PI * 2;
+	}
+
+	ctx.strokeStyle = ink;
+	ctx.lineWidth = SEGMENT_WIDTH + 2 * OUTLINE_WIDTH;
+	ctx.lineCap = "round";
+	ctx.strokeStyle = COLOR_BACKGROUND;
+	ctx.beginPath();
+	ctx.arc(
+		centerScreen.x,
+		centerScreen.y,
+		pointDistance(centerScreen, end1Screen),
+		a1,
+		a2,
+	);
+	ctx.stroke();
+	ctx.lineWidth = SEGMENT_WIDTH;
+	ctx.strokeStyle = ink;
+	ctx.stroke();
+}

--- a/index.html
+++ b/index.html
@@ -12,6 +12,9 @@
 			<input id="mode-lines" type="radio" name="mode"> Draw Lines
 		</label>
 		<label>
+			<input id="mode-draw-arcs" type="radio" name="mode"> Draw Arcs
+		</label>
+		<label>
 			<input id="mode-dimension" type="radio" name="mode"> Dimension
 		</label>
 		<label>

--- a/main.ts
+++ b/main.ts
@@ -819,7 +819,7 @@ about.canvas.addEventListener("mousedown", e => {
 			}
 		}
 		return false;
-	} else if (cursorMode.tag === 'draw-arc-mode') {
+	} else if (cursorMode.tag === "draw-arc-mode") {
 		if (e.button === 2) {
 			e.preventDefault();
 			cursorMode.center = null;

--- a/main.ts
+++ b/main.ts
@@ -144,6 +144,18 @@ function rerender(ctx: CanvasRenderingContext2D, canvas: HTMLCanvasElement): voi
 		const destination = choosePoint(lastMouseCursor);
 		graphics.drawSketchedSegment(ctx, view, cursorMode.from.position, destination.world);
 	}
+	if (cursorMode.tag === "draw-arc-mode") {
+		const destination = choosePoint(lastMouseCursor);
+		if (!cursorMode.center) {
+			// Nothing to draw
+		} else if (!cursorMode.end1) {
+			// Draw the radius
+			graphics.drawSketchedArc(ctx, view, cursorMode.center.position, destination.world, null);
+		} else if (!cursorMode.end2) {
+			// Draw the arc preview
+			graphics.drawSketchedArc(ctx, view, cursorMode.center.position, cursorMode.end1.position, destination.world);
+		}
+	}
 
 	const sketchingConstraint = convertSelectedFiguresToDimensionType();
 	if (sketchingConstraint !== null) {

--- a/saving.ts
+++ b/saving.ts
@@ -11,6 +11,11 @@ type SerializedFigure = {
 	from: FigureID,
 	to: FigureID,
 } | {
+	class: "ArcFigure",
+	center: FigureID,
+	end1: FigureID,
+	end2: FigureID,
+} | {
 	class: "DimensionPointDistanceFigure",
 	from: FigureID,
 	to: FigureID,
@@ -49,6 +54,13 @@ function serializeFigure(
 			class: "SegmentFigure",
 			from: figureIDs(figure.from),
 			to: figureIDs(figure.to),
+		};
+	} else if (figure instanceof figures.ArcFigure) {
+		return {
+			class: "ArcFigure",
+			center: figureIDs(figure.center),
+			end1: figureIDs(figure.end1),
+			end2: figureIDs(figure.end2),
 		};
 	} else if (figure instanceof figures.DimensionPointDistanceFigure) {
 		return {
@@ -146,6 +158,12 @@ export function deserializeFigure(
 			figureWithID(object.from) as figures.PointFigure,
 			figureWithID(object.to) as figures.PointFigure,
 		);
+	} else if (object.class === 'ArcFigure') {
+		return new figures.ArcFigure(
+			figureWithID(object.center) as figures.PointFigure,
+			figureWithID(object.end1) as figures.PointFigure,
+			figureWithID(object.end2) as figures.PointFigure,
+		)
 	}
 	const _: never = object;
 	console.error("deserializeFigure:", object);


### PR DESCRIPTION
Allows the construction of circular arcs. The three points are currently unconstrained relative to each other; the arc is drawn with provided `center` through the point `end1`, to the angle of (but not necessarily radius of) `end2`.

<img width="776" alt="Screenshot 2023-11-25 at 10 38 30 PM" src="https://github.com/CurtisFenner/twill-drafting/assets/6179181/317dd82f-a03d-4493-a305-e3dce4dfd077">
