### PR TITLE
Highlight point selected by dimension tool

### DIFF
--- a/graphics.ts
+++ b/graphics.ts
@@ -117,9 +117,21 @@ export function drawSketchedArc(
 		);
 		ctx.stroke();
 	}
+}
 
-
-
+export function drawHighlightedPoint(
+	ctx: CanvasRenderingContext2D,
+	view: View,
+	atWorld: Position,
+): void {
+	ctx.lineWidth = SEGMENT_WIDTH;
+	ctx.lineCap = "round";
+	ctx.strokeStyle = COLOR_SELECTED;
+	const atScreen = view.toScreen(atWorld);
+	ctx.beginPath();
+	ctx.arc(atScreen.x, atScreen.y, SEGMENT_WIDTH * 3, 0, 6.28);
+	ctx.closePath();
+	ctx.stroke();
 }
 
 export function drawLengthDimension(

--- a/main.ts
+++ b/main.ts
@@ -156,6 +156,14 @@ function rerender(ctx: CanvasRenderingContext2D, canvas: HTMLCanvasElement): voi
 			graphics.drawSketchedArc(ctx, view, cursorMode.center.position, cursorMode.end1.position, destination.world);
 		}
 	}
+	if (cursorMode.tag === 'dimension') {
+		if (cursorMode.constraining.length === 1) {
+			const constrainingFigure = cursorMode.constraining[0];
+			if (constrainingFigure instanceof figures.PointFigure) {
+				graphics.drawHighlightedPoint(ctx, view, constrainingFigure.position);
+			}
+		}
+	}
 
 	const sketchingConstraint = convertSelectedFiguresToDimensionType();
 	if (sketchingConstraint !== null) {


### PR DESCRIPTION
This makes the visual state of the dimension tool clearer, when applied to two points.

This screenshot shows how it looks, when selecting the top-left point in the triangle.

<img width="395" alt="Screenshot 2023-11-27 at 8 37 53 PM" src="https://github.com/CurtisFenner/twill-drafting/assets/6179181/2b3d88c3-2c4c-4c8d-b8c7-305a0a1641d1">
